### PR TITLE
Include "Cancelled" in Skipped Statuses

### DIFF
--- a/src/normalize_needed_jobs_status.py
+++ b/src/normalize_needed_jobs_status.py
@@ -128,7 +128,7 @@ def main(argv):
         job['result'] == 'success' for name, job in jobs.items()
         if name not in (jobs_allowed_to_fail | jobs_allowed_to_be_skipped)
     ) and all(
-        job['result'] in {'skipped', 'success'} for name, job in jobs.items()
+        job['result'] in {'skipped', 'cancelled', 'success'} for name, job in jobs.items()
         if name in jobs_allowed_to_be_skipped
     )
     set_final_result_outputs(job_matrix_succeeded)


### PR DESCRIPTION
Jobs can be cancelled externally, either manually or automatically with an action. Cancelled jobs fall into the "failure" state of this action, and since they are not explicit failures they should be considered as "skipped" in the same way that jobs which are automatically skipped are.