### PR TITLE
🐛 Use allowed-failures and skips equally

### DIFF
--- a/src/normalize_needed_jobs_status.py
+++ b/src/normalize_needed_jobs_status.py
@@ -166,6 +166,9 @@ def main(argv: list[str]) -> int:
     jobs = inputs['jobs'] or {}
     jobs_allowed_to_fail = set(inputs['allowed_failures'] or [])
     jobs_allowed_to_be_skipped = set(inputs['allowed_skips'] or [])
+    print(f'{jobs=}')
+    print(f'{jobs_allowed_to_fail=}')
+    print(f'{jobs_allowed_to_be_skipped=}')
 
     if not jobs:
         with summary_file_path.open(  # type: ignore[misc]
@@ -193,10 +196,28 @@ def main(argv: list[str]) -> int:
         if job_name in jobs_allowed_to_fail:
             allowed_outcome_map[job_name].add('failure')
 
+    print(f'{allowed_outcome_map=}')
+    print(
+        f"""{
+            [
+                job['result'] == 'success' for name, job in jobs.items()
+                if name not in (jobs_allowed_to_fail | jobs_allowed_to_be_skipped)
+            ]=
+        }""",
+    )
+    print(
+        f"""{
+            [
+                (name, job['result'] in {'skipped', 'success'}) for name, job in jobs.items()
+                if name in jobs_allowed_to_be_skipped
+            ]=
+        }""",
+    )
     job_matrix_succeeded = all(
         job['result'] in allowed_outcome_map[name]
         for name, job in jobs.items()
     )
+    print(f'{job_matrix_succeeded=}')
     set_final_result_outputs(job_matrix_succeeded)
 
     allowed_to_fail_jobs_succeeded = all(
@@ -204,12 +225,14 @@ def main(argv: list[str]) -> int:
         for name, job in jobs.items()
         if name in jobs_allowed_to_fail
     )
+    print(f'{allowed_to_fail_jobs_succeeded=}')
 
     allowed_to_be_skipped_jobs_succeeded = all(
         job['result'] == 'success'
         for name, job in jobs.items()
         if name in jobs_allowed_to_be_skipped
     )
+    print(f'{allowed_to_be_skipped_jobs_succeeded=}')
 
     with summary_file_path.open(  # type: ignore[misc]
         mode=FILE_APPEND_MODE,

--- a/src/normalize_needed_jobs_status.py
+++ b/src/normalize_needed_jobs_status.py
@@ -185,14 +185,17 @@ def main(argv: list[str]) -> int:
             )
         return 1
 
+    allowed_outcome_map = {}
+    for job_name in jobs:
+        allowed_outcome_map[job_name] = {'success'}
+        if job_name in jobs_allowed_to_be_skipped:
+            allowed_outcome_map[job_name].add('skipped')
+        if job_name in jobs_allowed_to_fail:
+            allowed_outcome_map[job_name].add('failure')
+
     job_matrix_succeeded = all(
-        job['result'] == 'success'
+        job['result'] in allowed_outcome_map[name]
         for name, job in jobs.items()
-        if name not in (jobs_allowed_to_fail | jobs_allowed_to_be_skipped)
-    ) and all(
-        job['result'] in {'skipped', 'success'}
-        for name, job in jobs.items()
-        if name in jobs_allowed_to_be_skipped
     )
     set_final_result_outputs(job_matrix_succeeded)
 


### PR DESCRIPTION
Before this patch, `allowed-failures` did not contribute to the overall computed outcome due to a bug in the checking logic. This change refactors the data strucutures used to simplify the check and reduce its complexity in general.

Fixes #23