### PR TITLE
Fix script injection risk by passing inputs via env vars

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,20 +48,14 @@ runs:
   - name: Decide whether the input jobs succeeded or failed
     id: outcome
     env:
+      INPUT_ALLOWED_FAILURES: ${{ inputs.allowed-failures }}
+      INPUT_ALLOWED_SKIPS: ${{ inputs.allowed-skips }}
+      INPUT_JOBS: ${{ inputs.jobs }}
       PYTHONPATH: ${{ github.action_path }}/src
     run: |
       python -m normalize_needed_jobs_status \
-      "$(cat << EOM
-        ${{ inputs.allowed-failures }}
-      EOM
-      )" \
-      "$(cat << EOM
-        ${{ inputs.allowed-skips }}
-      EOM
-      )" \
-      "$(cat << EOM
-        ${{ inputs.jobs }}
-      EOM
-      )"
+        "$INPUT_ALLOWED_FAILURES" \
+        "$INPUT_ALLOWED_SKIPS" \
+        "$INPUT_JOBS"
     shell: bash
 ...


### PR DESCRIPTION
## Summary

- Moves `${{ inputs.* }}` interpolation from the `run:` script body into the `env:` block, referencing values as shell variables instead.
- This prevents potential script injection via crafted input values — environment variables are assigned before the shell interprets the script, so values can never break out of their string context.
- Also eliminates the heredoc complexity, improving readability.

## Problem

The current `action.yml` interpolates inputs directly into the bash script body using `${{ inputs.* }}` inside heredocs. If an attacker controls any input value (e.g. through a dynamically constructed `allowed-failures` sourced from untrusted data), they could inject arbitrary shell commands by crafting a value that breaks out of the heredoc delimiter.

## Solution

Pass inputs through the `env:` block instead:

```yaml
env:
  INPUT_ALLOWED_FAILURES: ${{ inputs.allowed-failures }}
  INPUT_ALLOWED_SKIPS: ${{ inputs.allowed-skips }}
  INPUT_JOBS: ${{ inputs.jobs }}
run: |
  python -m normalize_needed_jobs_status \
    "$INPUT_ALLOWED_FAILURES" \
    "$INPUT_ALLOWED_SKIPS" \
    "$INPUT_JOBS"
```

This is the recommended pattern per [GitHub's security hardening docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).